### PR TITLE
feat: v1.3.0 — Grid Rows (guías horizontales)

### DIFF
--- a/.claude/epics/grid-rows/23.md
+++ b/.claude/epics/grid-rows/23.md
@@ -1,0 +1,67 @@
+---
+name: generateRowGuides — servicio de generación de guías horizontales
+status: open
+created: 2026-03-10T16:57:51Z
+updated: 2026-03-10T16:57:51Z
+epic: grid-rows
+stream: A
+size: S
+depends_on: []
+github: https://github.com/misterfulanito/guidemygrid/issues/23
+---
+
+# generateRowGuides — servicio de generación de guías horizontales
+
+## Descripción
+
+Añadir la función `generateRowGuides` en `src/services/gridGenerator.ts`, espejo exacto de `generateColumnGuides` pero para el eje Y (guías horizontales).
+
+## Archivo a modificar
+
+`src/services/gridGenerator.ts`
+
+## Implementación
+
+```ts
+/**
+ * Generate horizontal guide positions for a row grid.
+ * Returns absolute Y positions (top and bottom edge of each row).
+ */
+export function generateRowGuides(params: {
+  rows: number;
+  gutter: number;
+  containerHeight: number;
+  offsetY: number;
+}): number[] {
+  const { rows, gutter, containerHeight, offsetY } = params;
+
+  if (rows <= 0 || containerHeight <= 0) return [];
+
+  const rowHeight = (containerHeight - (rows - 1) * gutter) / rows;
+
+  if (rowHeight <= 0) {
+    throw new GridGenerationError(
+      `Gutter too large: row height would be ${Math.round(rowHeight)}px`
+    );
+  }
+
+  const positions: number[] = [];
+  for (let i = 0; i < rows; i++) {
+    const top = offsetY + i * (rowHeight + gutter);
+    const bottom = top + rowHeight;
+    positions.push(Math.round(top * 100) / 100);
+    positions.push(Math.round(bottom * 100) / 100);
+  }
+
+  return [...new Set(positions)].sort((a, b) => a - b);
+}
+```
+
+## Criterios de aceptación
+
+- [ ] `generateRowGuides` exportada desde `gridGenerator.ts`
+- [ ] Misma firma de error que `generateColumnGuides` (`GridGenerationError`)
+- [ ] `rows=1, gutter=0, containerHeight=900, offsetY=0` → `[0, 900]`
+- [ ] `rows=3, gutter=20, containerHeight=500, offsetY=0` → 6 posiciones correctas
+- [ ] `rows=2, gutter=600, containerHeight=500` → lanza `GridGenerationError`
+- [ ] `offsetY > 0` (selection) → posiciones relativas al offset correctas

--- a/.claude/epics/grid-rows/24.md
+++ b/.claude/epics/grid-rows/24.md
@@ -1,0 +1,62 @@
+---
+name: RowsState — tipos y store para filas
+status: open
+created: 2026-03-10T16:57:51Z
+updated: 2026-03-10T16:57:51Z
+epic: grid-rows
+stream: B
+size: S
+depends_on: []
+github: https://github.com/misterfulanito/guidemygrid/issues/24
+---
+
+# RowsState — tipos y store para filas
+
+## Descripción
+
+Añadir el estado de filas al store de Zustand, espejando el estado de columnas. Dos archivos a modificar.
+
+## Archivos a modificar
+
+### 1. `src/types/store.types.ts`
+
+Añadir `RowsState` e incluirla en `GridStore`:
+
+```ts
+export interface RowsState {
+  count: string;  // '' or numeric string
+  gutter: string; // '' or numeric string
+}
+
+export interface GridStore {
+  columns: ColumnsState;
+  setColumns: (partial: Partial<ColumnsState>) => void;
+  rows: RowsState;
+  setRows: (partial: Partial<RowsState>) => void;
+}
+```
+
+### 2. `src/store/gridStore.ts`
+
+Añadir rows al store:
+
+```ts
+export const useGridStore = create<GridStore>((set) => ({
+  columns: { count: '', gutter: '' },
+  setColumns: (partial) =>
+    set((state) => ({ columns: { ...state.columns, ...partial } })),
+
+  rows: { count: '', gutter: '' },
+  setRows: (partial) =>
+    set((state) => ({ rows: { ...state.rows, ...partial } })),
+}));
+```
+
+## Criterios de aceptación
+
+- [ ] `RowsState` exportada desde `store.types.ts`
+- [ ] `GridStore` tiene `rows: RowsState` y `setRows`
+- [ ] `useGridStore()` expone `rows` y `setRows`
+- [ ] Estado inicial: `rows = { count: '', gutter: '' }`
+- [ ] `setRows({ count: '5' })` actualiza solo `count`, preserva `gutter`
+- [ ] No rompe el estado de `columns` existente

--- a/.claude/epics/grid-rows/25.md
+++ b/.claude/epics/grid-rows/25.md
@@ -1,0 +1,137 @@
+---
+name: Rows section UI — componente y wiring en GridPanel
+status: open
+created: 2026-03-10T16:57:51Z
+updated: 2026-03-10T16:57:51Z
+epic: grid-rows
+stream: C
+size: M
+depends_on: [23, 24]
+github: https://github.com/misterfulanito/guidemygrid/issues/25
+---
+
+# Rows section UI — componente y wiring en GridPanel
+
+## Descripción
+
+Añadir la sección "rows" al componente `GridPanel.tsx`. Requiere tareas 001 y 002 completas.
+
+## Archivo a modificar
+
+`src/components/ColumnGrid/GridPanel.tsx`
+
+## Cambios
+
+### 1. Añadir `IconRows` (debajo de `IconColumns`)
+
+```tsx
+function IconRows() {
+  return (
+    <svg className={styles.sectionIcon} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <rect x="2" y="1" width="12" height="3.5" rx="0.5"/>
+      <rect x="2" y="6.25" width="12" height="3.5" rx="0.5"/>
+      <rect x="2" y="11.5" width="12" height="3.5" rx="0.5"/>
+    </svg>
+  );
+}
+```
+
+### 2. Añadir variables de rows en `GridPanel`
+
+```tsx
+const { columns, setColumns, rows, setRows } = useGridStore();
+
+const rowCountNum = parseFloat(rows.count);
+const rowGutterNum = parseFloat(rows.gutter) || 0;
+const hasRowCount = rows.count !== '' && !isNaN(rowCountNum) && rowCountNum > 0;
+const rowGutterDisabled = !hasRowCount;
+
+const offsetY = selection ? selection.top : 0;
+
+const computedHeightPx = hasRowCount && containerHeight > 0
+  ? (containerHeight - (rowCountNum - 1) * rowGutterNum) / rowCountNum
+  : NaN;
+const heightDisplay = !isNaN(computedHeightPx) && computedHeightPx > 0
+  ? String(Math.round(computedHeightPx * 100) / 100)
+  : '';
+```
+
+### 3. Actualizar `addDisabled`
+
+```tsx
+const addDisabled = (!hasCount && !hasRowCount) || !document || isApplying;
+```
+
+### 4. Actualizar `handleAdd`
+
+```tsx
+const handleAdd = async () => {
+  if (addDisabled) return;
+  setApplying(true);
+  setError(null);
+  try {
+    const vertical = hasCount
+      ? generateColumnGuides({ columns: countNum, gutter: gutterNum, containerWidth, offsetX })
+      : [];
+    const horizontal = hasRowCount
+      ? generateRowGuides({ rows: rowCountNum, gutter: rowGutterNum, containerHeight, offsetY })
+      : [];
+    await photoshopBridge.applyGuides({ vertical, horizontal }, 'replace');
+  } catch (err) {
+    setError(err instanceof GridGenerationError ? err.message : 'Error applying guides');
+  } finally {
+    setApplying(false);
+  }
+};
+```
+
+### 5. Añadir import de `generateRowGuides`
+
+```tsx
+import { generateColumnGuides, generateRowGuides, GridGenerationError } from '../../services/gridGenerator';
+```
+
+### 6. Añadir sección Rows en el JSX (después de la sección Columns)
+
+```tsx
+{/* Rows section */}
+<div className={styles.section}>
+  <div className={styles.sectionHead}>
+    <IconRows />
+    <span className={styles.sectionLabel}>rows</span>
+  </div>
+
+  <div className={styles.row3}>
+    <NumInput
+      placeholder="Quantity"
+      value={rows.count}
+      onChange={(v) => setRows({ count: v })}
+    />
+    <NumInput
+      placeholder="Height"
+      value={heightDisplay}
+      disabled={true}
+    />
+    <NumInput
+      placeholder="Gutter"
+      value={rows.gutter}
+      disabled={rowGutterDisabled}
+      onChange={(v) => setRows({ gutter: v })}
+    />
+  </div>
+</div>
+```
+
+## Criterios de aceptación
+
+- [ ] Sección "rows" aparece debajo de "Columns" en el panel
+- [ ] Label en minúscula "rows" (igual que en el diseño Pencil)
+- [ ] IconRows son rectángulos horizontales (transpuesto de IconColumns)
+- [ ] Height se calcula y muestra automáticamente cuando Quantity tiene valor
+- [ ] Gutter deshabilitado hasta que Quantity tenga valor
+- [ ] Add guides con solo Rows → genera solo guías horizontales
+- [ ] Add guides con solo Columns → genera solo guías verticales (sin regresión)
+- [ ] Add guides con ambos → genera ambas simultáneamente
+- [ ] Add guides deshabilitado si AMBOS (columns y rows) están vacíos
+- [ ] Selection offset (offsetY) aplicado correctamente en guías horizontales
+- [ ] Sin errores de TypeScript ni de consola UXP

--- a/.claude/epics/grid-rows/26.md
+++ b/.claude/epics/grid-rows/26.md
@@ -1,6 +1,6 @@
 ---
 name: QA manual + bump versión a v1.3.0
-status: open
+status: closed
 created: 2026-03-10T16:57:51Z
 updated: 2026-03-10T16:57:51Z
 epic: grid-rows

--- a/.claude/epics/grid-rows/26.md
+++ b/.claude/epics/grid-rows/26.md
@@ -1,0 +1,56 @@
+---
+name: QA manual + bump versión a v1.3.0
+status: open
+created: 2026-03-10T16:57:51Z
+updated: 2026-03-10T16:57:51Z
+epic: grid-rows
+stream: -
+size: XS
+depends_on: [25]
+github: https://github.com/misterfulanito/guidemygrid/issues/26
+---
+
+# QA manual + bump versión a v1.3.0
+
+## Descripción
+
+Verificar la funcionalidad completa de Rows en Photoshop y actualizar la versión del plugin.
+
+## Checklist QA
+
+### Funcionalidad Rows
+
+- [ ] Rows + Columns → guías horizontales y verticales en canvas
+- [ ] Solo Rows → guías horizontales en canvas
+- [ ] Solo Columns → guías verticales en canvas (sin regresión)
+- [ ] Rows sobre Selection → guías en posición correcta relativa al selection
+- [ ] Gutter grande → mensaje de error `GridGenerationError`
+- [ ] Remove → elimina todas las guías (sin cambios en comportamiento)
+
+### Edge cases
+
+- [ ] Rows.count = 1, gutter = 0 → 2 guías: top y bottom del canvas
+- [ ] Rows.count vacío → no genera horizontales (Add guide solo si Columns tiene valor)
+- [ ] Ambos vacíos → botón Add deshabilitado
+
+### Build
+
+- [ ] `npm run build` sin errores TypeScript
+- [ ] Plugin carga en Photoshop vía UXP Developer Tool
+
+## Bump de versión
+
+Archivo: `src/version.ts`
+
+Cambiar de `v1.2.0` a `v1.3.0`:
+
+```ts
+export const VERSION = '1.3.0';
+```
+
+## Criterios de aceptación
+
+- [ ] Todas las pruebas QA pasadas
+- [ ] Build limpio sin warnings TypeScript
+- [ ] `version.ts` actualizado a `1.3.0`
+- [ ] Version bar del plugin muestra "GuideMyGrid v1.3.0"

--- a/.claude/epics/grid-rows/epic.md
+++ b/.claude/epics/grid-rows/epic.md
@@ -1,0 +1,100 @@
+---
+name: grid-rows
+status: backlog
+created: 2026-03-10T16:57:51Z
+updated: 2026-03-10T16:57:51Z
+progress: 0%
+github: https://github.com/misterfulanito/guidemygrid/issues/22
+prd: .claude/prds/grid-rows.md
+---
+
+# Epic: Grid Rows — Guías Horizontales
+
+## 🎯 Overview
+
+Añadir la sección "Rows" al panel Grid del plugin GuideMyGrid. La funcionalidad espeja exactamente la sección Columns pero en el eje Y: genera guías horizontales con los mismos tres campos (Quantity, Height auto-calculado, Gutter). Ambas secciones coexisten en el mismo panel y el botón "Add guides" genera vertical + horizontal simultáneamente cuando ambas tienen valores.
+
+## 🏗️ Arquitectura
+
+### Diseño de referencia
+Frame "GuideForge - Rows" en GuideMyGrid.pen: Columns section + Rows section en el mismo panel, mismos estilos, footer compartido.
+
+### Capas afectadas
+
+| Capa | Archivo | Cambio |
+|------|---------|--------|
+| Service | `src/services/gridGenerator.ts` | Añadir `generateRowGuides()` |
+| Store types | `src/types/store.types.ts` | Añadir `RowsState`, extender `GridStore` |
+| Store | `src/store/gridStore.ts` | Añadir rows state + `setRows` |
+| UI | `src/components/ColumnGrid/GridPanel.tsx` | Añadir sección Rows + wiring |
+
+### No tocar
+- `src/types/grid.types.ts` — `RowConfig` ya existe, no relevante para MVP
+- `src/services/photoshopBridge.ts` — ya acepta `{ vertical, horizontal }`
+- `GridPanel.module.css` — todas las clases son reutilizables sin cambios
+
+### Lógica `generateRowGuides`
+
+Espejo exacto de `generateColumnGuides` para el eje Y:
+```ts
+// rowHeight = (containerHeight - (rows-1) * gutter) / rows
+// Para cada fila i: top = offsetY + i*(rowHeight+gutter), bottom = top + rowHeight
+// Retorna posiciones Y absolutas únicas ordenadas
+```
+
+### Lógica `handleAdd` actualizada
+
+```ts
+const vertical = hasColCount ? generateColumnGuides({...}) : [];
+const horizontal = hasRowCount ? generateRowGuides({...}) : [];
+if (vertical.length === 0 && horizontal.length === 0) return;
+await photoshopBridge.applyGuides({ vertical, horizontal }, 'replace');
+```
+
+### `containerHeight` y `offsetY`
+
+Ya disponibles en GridPanel desde `useDocument` + `useSelection`:
+- `containerHeight = selection ? selection.height : document.height`
+- `offsetY = selection ? selection.top : 0`
+
+## 🔄 Work Streams
+
+### Stream A: Service Layer
+**Archivos:** `src/services/gridGenerator.ts`
+**Paralelo:** independiente
+
+### Stream B: Store Layer
+**Archivos:** `src/types/store.types.ts`, `src/store/gridStore.ts`
+**Paralelo:** independiente de A
+
+### Stream C: UI Layer
+**Archivos:** `src/components/ColumnGrid/GridPanel.tsx`
+**Depende de:** A + B completos
+
+## 📊 Task Summary
+
+| # | Task | Stream | Tamaño |
+|---|------|--------|--------|
+| 1 | `generateRowGuides` en gridGenerator.ts | A | S |
+| 2 | RowsState + GridStore types + gridStore.ts | B | S |
+| 3 | Rows section UI en GridPanel.tsx + wiring | C | M |
+| 4 | QA manual + bump versión a v1.3.0 | - | XS |
+
+**Total:** 4 tasks · Effort estimado: ~1 día · Crítico: A+B antes de C
+
+## ✅ Acceptance Criteria
+
+- [ ] Sección Rows aparece debajo de Columns con campos Quantity / Height / Gutter
+- [ ] Height se auto-calcula (containerHeight - (rows-1)*gutter) / rows
+- [ ] Gutter deshabilitado hasta que Quantity tenga valor
+- [ ] Add guides genera horizontal + vertical según qué campos tengan valor
+- [ ] Funciona sobre Canvas y sobre Selection (usa offsetY correcto)
+- [ ] No rompe comportamiento actual de Columns
+- [ ] Sin errores en consola UXP
+
+## Tasks Created
+
+- #1: generateRowGuides — servicio de generación de guías horizontales
+- #2: RowsState — tipos y store para filas
+- #3: Rows section UI — componente y wiring en GridPanel
+- #4: QA + versión v1.3.0

--- a/.claude/epics/grid-rows/github-mapping.md
+++ b/.claude/epics/grid-rows/github-mapping.md
@@ -1,0 +1,11 @@
+# GitHub Issue Mapping
+
+Epic: #22 - https://github.com/misterfulanito/guidemygrid/issues/22
+
+Tasks:
+- #23: generateRowGuides — servicio de generación de guías horizontales - https://github.com/misterfulanito/guidemygrid/issues/23
+- #24: RowsState — tipos y store para filas - https://github.com/misterfulanito/guidemygrid/issues/24
+- #25: Rows section UI — componente y wiring en GridPanel - https://github.com/misterfulanito/guidemygrid/issues/25
+- #26: QA manual + bump versión a v1.3.0 - https://github.com/misterfulanito/guidemygrid/issues/26
+
+Synced: 2026-03-10T16:57:51Z

--- a/.claude/prds/grid-rows.md
+++ b/.claude/prds/grid-rows.md
@@ -1,0 +1,88 @@
+---
+name: grid-rows
+description: Añadir sección de filas (rows) al panel Grid del plugin GuideMyGrid
+status: backlog
+created: 2026-03-10T16:57:51Z
+updated: 2026-03-10T16:57:51Z
+---
+
+# PRD: Grid Rows — Guías Horizontales
+
+## Objetivo
+
+Añadir una sección de filas (rows) al panel Grid del plugin GuideMyGrid, espejando la funcionalidad de columns pero para el eje vertical (guías horizontales).
+
+## Contexto
+
+El panel Grid actualmente solo genera guías verticales (columns). El diseño de referencia en Pencil ("GuideForge - Rows") muestra ambas secciones — Columns y Rows — en el mismo panel, compartiendo footer y botones de acción.
+
+## Funcionalidad requerida
+
+### Sección Rows (debajo de Columns)
+
+- **Quantity**: número de filas (campo editable, mismo comportamiento que columns.count)
+- **Height**: altura de cada fila, auto-calculada y deshabilitada (= (containerHeight - (rows-1)*gutter) / rows)
+- **Gutter**: espacio entre filas en px (deshabilitado hasta que Quantity tenga valor)
+
+### Comportamiento del botón "Add guides"
+
+- Si solo Columns tiene valores → genera guías verticales (comportamiento actual)
+- Si solo Rows tiene valores → genera guías horizontales
+- Si ambos tienen valores → genera ambas simultáneamente
+- El modo siempre es 'replace' (comportamiento actual)
+
+### Comportamiento del botón "Remove"
+
+- Sin cambios: elimina todas las guías del documento (comportamiento actual)
+
+## Diseño UI
+
+Referencia: frame "GuideForge - Rows" en GuideMyGrid.pen
+
+```
+┌─────────────────────────────────┐
+│ Grid                         👁 │
+├─────────────────────────────────┤
+│ Context: Canvas 1440 × 900 px  │
+├─────────────────────────────────┤
+│  ⊞ Columns                      │
+│  [ Quantity ] [ Width ] [Gutter]│
+│                                 │
+│  ≡ rows                         │
+│  [ Quantity ] [Height] [Gutter] │
+├─────────────────────────────────┤
+│  [   + Add guides   ] [Remove]  │
+│  GuideMyGrid v1.x.x            │
+└─────────────────────────────────┘
+```
+
+- Icono Rows: líneas horizontales (igual que el Rows icon del diseño Pencil)
+- Mismo layout de 3 inputs `.row3`
+- Mismos estilos: `.section`, `.sectionHead`, `.sectionIcon`, `.sectionLabel`
+
+## Alcance técnico
+
+### Archivos a modificar
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/services/gridGenerator.ts` | Añadir `generateRowGuides()` |
+| `src/types/store.types.ts` | Añadir `RowsState`, extender `GridStore` |
+| `src/store/gridStore.ts` | Añadir rows state + `setRows` action |
+| `src/components/ColumnGrid/GridPanel.tsx` | Añadir sección Rows UI + wiring |
+
+### Archivos NO modificar
+
+- `src/types/grid.types.ts` — `RowConfig` ya definida (no se usa en MVP, no tocar)
+- `src/services/photoshopBridge.ts` — ya acepta `{ vertical, horizontal }`
+- `GridPanel.module.css` — reutilizar clases existentes sin cambios
+
+## Criterios de aceptación
+
+- [ ] Sección Rows aparece debajo de Columns en el panel
+- [ ] Height se calcula automáticamente igual que Width en Columns
+- [ ] Gutter deshabilitado hasta que Quantity tenga valor
+- [ ] "Add guides" genera guías horizontales + verticales según campos con valor
+- [ ] Funciona sobre Canvas y sobre Selection
+- [ ] No rompe el comportamiento actual de Columns
+- [ ] Sin errores en consola UXP

--- a/src/components/ColumnGrid/GridPanel.tsx
+++ b/src/components/ColumnGrid/GridPanel.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useGridStore, useUIStore } from '../../store';
 import { useDocument } from '../../hooks/useDocument';
 import { photoshopBridge } from '../../services/photoshopBridge';
-import { generateColumnGuides, GridGenerationError } from '../../services/gridGenerator';
+import { generateColumnGuides, generateRowGuides, GridGenerationError } from '../../services/gridGenerator';
 import { VERSION } from '../../version';
 import styles from './GridPanel.module.css';
 
@@ -16,6 +16,16 @@ function IconColumns() {
       <rect x="1" y="2" width="3.5" height="12" rx="0.5"/>
       <rect x="6.25" y="2" width="3.5" height="12" rx="0.5"/>
       <rect x="11.5" y="2" width="3.5" height="12" rx="0.5"/>
+    </svg>
+  );
+}
+
+function IconRows() {
+  return (
+    <svg className={styles.sectionIcon} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <rect x="2" y="1" width="12" height="3.5" rx="0.5"/>
+      <rect x="2" y="6.25" width="12" height="3.5" rx="0.5"/>
+      <rect x="2" y="11.5" width="12" height="3.5" rx="0.5"/>
     </svg>
   );
 }
@@ -67,7 +77,7 @@ function NumInput({ placeholder, value, disabled, onChange }: NumInputProps) {
 // ── GridPanel ─────────────────────────────────────────────────────────────
 
 export function GridPanel() {
-  const { columns, setColumns } = useGridStore();
+  const { columns, setColumns, rows, setRows } = useGridStore();
   const { isApplying, lastError, setApplying, setError } = useUIStore();
   const { document, selection } = useDocument();
   const countNum = parseFloat(columns.count);
@@ -79,6 +89,19 @@ export function GridPanel() {
   const containerWidth = selection ? selection.width : (document?.width ?? 0);
   const containerHeight = selection ? selection.height : (document?.height ?? 0);
   const offsetX = selection ? selection.left : 0;
+
+  const rowCountNum = parseFloat(rows.count);
+  const rowGutterNum = parseFloat(rows.gutter) || 0;
+  const hasRowCount = rows.count !== '' && !isNaN(rowCountNum) && rowCountNum > 0;
+  const rowGutterDisabled = !hasRowCount;
+  const offsetY = selection ? selection.top : 0;
+
+  const computedHeightPx = hasRowCount && containerHeight > 0
+    ? (containerHeight - (rowCountNum - 1) * rowGutterNum) / rowCountNum
+    : NaN;
+  const heightDisplay = !isNaN(computedHeightPx) && computedHeightPx > 0
+    ? String(Math.round(computedHeightPx * 100) / 100)
+    : '';
 
   // Context bar
   const contextSource = selection ? 'Selection' : 'Canvas';
@@ -94,20 +117,20 @@ export function GridPanel() {
     ? String(Math.round(computedWidthPx * 100) / 100)
     : '';
 
-  const addDisabled = !hasCount || !document || isApplying;
+  const addDisabled = (!hasCount && !hasRowCount) || !document || isApplying;
 
   const handleAdd = async () => {
     if (addDisabled) return;
     setApplying(true);
     setError(null);
     try {
-      const positions = generateColumnGuides({
-        columns: countNum,
-        gutter: gutterNum,
-        containerWidth,
-        offsetX,
-      });
-      await photoshopBridge.applyGuides({ vertical: positions, horizontal: [] }, 'replace');
+      const vertical = hasCount
+        ? generateColumnGuides({ columns: countNum, gutter: gutterNum, containerWidth, offsetX })
+        : [];
+      const horizontal = hasRowCount
+        ? generateRowGuides({ rows: rowCountNum, gutter: rowGutterNum, containerHeight, offsetY })
+        : [];
+      await photoshopBridge.applyGuides({ vertical, horizontal }, 'replace');
     } catch (err) {
       setError(err instanceof GridGenerationError ? err.message : 'Error applying guides');
     } finally {
@@ -166,6 +189,33 @@ export function GridPanel() {
               value={columns.gutter}
               disabled={gutterDisabled}
               onChange={(v) => setColumns({ gutter: v })}
+            />
+          </div>
+        </div>
+
+        {/* Rows section */}
+        <div className={styles.section}>
+          <div className={styles.sectionHead}>
+            <IconRows />
+            <span className={styles.sectionLabel}>rows</span>
+          </div>
+
+          <div className={styles.row3}>
+            <NumInput
+              placeholder="Quantity"
+              value={rows.count}
+              onChange={(v) => setRows({ count: v })}
+            />
+            <NumInput
+              placeholder="Height"
+              value={heightDisplay}
+              disabled={true}
+            />
+            <NumInput
+              placeholder="Gutter"
+              value={rows.gutter}
+              disabled={rowGutterDisabled}
+              onChange={(v) => setRows({ gutter: v })}
             />
           </div>
         </div>

--- a/src/services/gridGenerator.ts
+++ b/src/services/gridGenerator.ts
@@ -39,3 +39,36 @@ export function generateColumnGuides(params: {
 
   return [...new Set(positions)].sort((a, b) => a - b);
 }
+
+/**
+ * Generate horizontal guide positions for a row grid.
+ * Returns absolute Y positions (top and bottom edge of each row).
+ */
+export function generateRowGuides(params: {
+  rows: number;
+  gutter: number;
+  containerHeight: number;
+  offsetY: number;
+}): number[] {
+  const { rows, gutter, containerHeight, offsetY } = params;
+
+  if (rows <= 0 || containerHeight <= 0) return [];
+
+  const rowHeight = (containerHeight - (rows - 1) * gutter) / rows;
+
+  if (rowHeight <= 0) {
+    throw new GridGenerationError(
+      `Gutter too large: row height would be ${Math.round(rowHeight)}px`
+    );
+  }
+
+  const positions: number[] = [];
+  for (let i = 0; i < rows; i++) {
+    const top = offsetY + i * (rowHeight + gutter);
+    const bottom = top + rowHeight;
+    positions.push(Math.round(top * 100) / 100);
+    positions.push(Math.round(bottom * 100) / 100);
+  }
+
+  return [...new Set(positions)].sort((a, b) => a - b);
+}

--- a/src/store/gridStore.ts
+++ b/src/store/gridStore.ts
@@ -7,4 +7,8 @@ export const useGridStore = create<GridStore>((set) => ({
 
   setColumns: (partial) =>
     set((state) => ({ columns: { ...state.columns, ...partial } })),
+
+  rows: { count: '', gutter: '' },
+  setRows: (partial) =>
+    set((state) => ({ rows: { ...state.rows, ...partial } })),
 }));

--- a/src/types/store.types.ts
+++ b/src/types/store.types.ts
@@ -5,9 +5,16 @@ export interface ColumnsState {
   gutter: string; // '' or numeric string
 }
 
+export interface RowsState {
+  count: string;  // '' or numeric string
+  gutter: string; // '' or numeric string
+}
+
 export interface GridStore {
   columns: ColumnsState;
   setColumns: (partial: Partial<ColumnsState>) => void;
+  rows: RowsState;
+  setRows: (partial: Partial<RowsState>) => void;
 }
 
 export interface UIStore {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.2.0';
+export const VERSION = '1.3.0';


### PR DESCRIPTION
## Summary

- Add Rows section to the Grid panel, mirroring the Columns section for horizontal guides
- `generateRowGuides` generates horizontal Y positions (top + bottom of each row)
- Rows state (`count`, `gutter`) managed in Zustand store alongside columns
- `Add guides` now generates vertical + horizontal simultaneously when both sections have values

## Changes

### Stream A — Service layer
- `src/services/gridGenerator.ts` — Add `generateRowGuides()` (mirror of `generateColumnGuides` for Y axis)

### Stream B — Store layer
- `src/types/store.types.ts` — Add `RowsState`, extend `GridStore` with `rows` + `setRows`
- `src/store/gridStore.ts` — Add rows initial state and `setRows` action

### Stream C — UI layer
- `src/components/ColumnGrid/GridPanel.tsx` — Add Rows section (Quantity / Height / Gutter), `IconRows` SVG, updated `handleAdd` logic

### Version
- `src/version.ts` — Bump to `1.3.0`

## Issues Addressed

- Closes #23
- Closes #24
- Closes #25
- Closes #26
- Epic: #22

## Testing

- [x] Build: `webpack 5 compiled successfully`
- [x] TypeScript: no errors
- [x] QA manual en Photoshop ✅

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)